### PR TITLE
update gleason circle stop ID to fix errors on the site

### DIFF
--- a/api/departures.js
+++ b/api/departures.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 
 export default async function handler(req, res) {
   const apiKey = process.env.API_KEY;
-  const apiUrl = 'https://external.transitapp.com/v3/public/stop_departures?global_stop_id=RITECHNY:548'; // Hardcoded API endpoint
+  const apiUrl = 'https://external.transitapp.com/v3/public/stop_departures?global_stop_id=RITECHNY:619'; // Hardcoded API endpoint
 
   try {
     const response = await axios.get(apiUrl, {


### PR DESCRIPTION
The site is currently erroring. This should fix it


The new ID was discovered using a query for https://external.transitapp.com/v3/public/nearby_routes?lat=43.083426&lon=-77.677530 (the location being roughly where the gleason circle stop is)